### PR TITLE
add conversion steps to remove redundant states

### DIFF
--- a/src/js/fsa/fsa.js
+++ b/src/js/fsa/fsa.js
@@ -41,6 +41,39 @@ export default class FSA {
     }
 
     /**
+     * Merge two states into a single state
+     *
+     * @param {String} s1 The first state
+     * @param {String} s2 The second state
+     */
+    mergeStates (s1, s2) {
+        // Create the new state
+        const newState = `${s1}+${s2}`
+        this.states.push(newState)
+        if (this.acceptStates.includes(s1)) { this.acceptStates.push(newState) }
+        if (this.startState === s1 || this.startState === s2) { this.startState = newState }
+
+        // Add loopback on the new state for every symbol
+        this.transitions[newState] = {}
+        for (const symbol of this.alphabet) {
+            this.transitions[newState][symbol] = [newState]
+        }
+
+        // Add incoming transitions to the new state using the old states' incoming transitions
+        for (const state of this.states.filter(e => e !== s1 && e !== s2)) {
+            for (const symbol of this.alphabet) {
+                if (this.transitions[state][symbol][0] === s1 || this.transitions[state][symbol][0] === s2) {
+                    this.transitions[state][symbol] = [newState]
+                }
+            }
+        }
+
+        // Remove the old states
+        this.removeState(s1)
+        this.removeState(s2)
+    }
+
+    /**
      * Get the array of arrays that describes the powerset of this FSA's states
      *
      * @example

--- a/src/js/fsa/nfa_converter.js
+++ b/src/js/fsa/nfa_converter.js
@@ -266,6 +266,9 @@ export default class NFAConverter {
             // Pop the first state from redundantStates
             const pairToMerge = this.redundantStates.shift()
 
+            this.dfa.removeState(pairToMerge[0])
+            this.dfa.removeState(pairToMerge[1])
+
             return [this.dfa, {
                 type: 'merge_states',
                 desc: `Merge redundant states {${pairToMerge[0]}} and {${pairToMerge[1]}}`,

--- a/src/js/fsa/nfa_converter.js
+++ b/src/js/fsa/nfa_converter.js
@@ -115,30 +115,7 @@ export default class NFAConverter {
                     }
 
                     if (redundant) {
-                        // Create the new state
-                        const newState = `${s1}+${s2}`
-                        tempDFA.states.push(newState)
-                        if (tempDFA.acceptStates.includes(s1)) { tempDFA.acceptStates.push(newState) }
-                        if (tempDFA.startState === s1 || tempDFA.startState === s2) { tempDFA.startState = newState }
-
-                        // Add loopback on the new state for every symbol
-                        tempDFA.transitions[newState] = {}
-                        for (const symbol of tempDFA.alphabet) {
-                            tempDFA.transitions[newState][symbol] = [newState]
-                        }
-
-                        // Add incoming transitions to the new state using the old states' incoming transitions
-                        for (const state of tempDFA.states.filter(e => e !== s1 && e !== s2)) {
-                            for (const symbol of tempDFA.alphabet) {
-                                if (tempDFA.transitions[state][symbol][0] === s1 || tempDFA.transitions[state][symbol][0] === s2) {
-                                    tempDFA.transitions[state][symbol] = [newState]
-                                }
-                            }
-                        }
-
-                        // Remove the old states
-                        tempDFA.removeState(s1)
-                        tempDFA.removeState(s2)
+                        tempDFA.mergeStates(s1, s2)
 
                         // Add the pair of redundant states to the list and recursively search for more
                         list.push([s1, s2])
@@ -296,8 +273,7 @@ export default class NFAConverter {
             }]
             this.steps.push(step)
 
-            this.dfa.removeState(pairToMerge[0])
-            this.dfa.removeState(pairToMerge[1])
+            this.dfa.mergeStates(pairToMerge[0], pairToMerge[1])
             return step
         }
 

--- a/src/js/fsa/visual_fsa.js
+++ b/src/js/fsa/visual_fsa.js
@@ -351,6 +351,7 @@ export default class VisualFSA extends EventHandler {
             const s2 = step.states[1]
             const n2 = this.getNode(s2)
             const newState = `${s1}+${s2}`
+            step.locations = [n1.loc, n2.loc]
 
             // Create the new state at the midpoint between the old states
             this.addNode(newState, new Location((n1.loc.x + n2.loc.x) / 2, (n1.loc.y + n2.loc.y) / 2))
@@ -409,6 +410,38 @@ export default class VisualFSA extends EventHandler {
                 for (const symbol of Object.keys(step.transitions)) {
                     for (const endState of step.transitions[symbol]) {
                         this.addTransition(step.state, endState, symbol)
+                    }
+                }
+            }
+
+            return this.render()
+        }
+
+        case 'merge_states': {
+            this.removeNode(`${step.states[0]}+${step.states[1]}`)
+            this.addNode(step.states[0], step.locations[0])
+            this.addNode(step.states[1], step.locations[1])
+
+            if (dfa.startState === step.states[0]) {
+                this.setStartState(step.states[0])
+            } else if (dfa.startState === step.states[1]) {
+                this.setStartState(step.states[1])
+            }
+
+            if (dfa.acceptStates.includes(step.states[0])) { this.addAcceptState(step.states[0]) }
+            if (dfa.acceptStates.includes(step.states[1])) { this.addAcceptState(step.states[1]) }
+
+            // Add external transitions between the two states
+            for (const state of dfa.states) {
+                for (const symbol of dfa.alphabet) {
+                    if (!dfa.transitions[state][symbol]) continue
+
+                    if (dfa.transitions[state][symbol].includes(step.states[0])) {
+                        this.addTransition(state, step.states[0], symbol)
+                    }
+
+                    if (dfa.transitions[state][symbol].includes(step.states[1])) {
+                        this.addTransition(state, step.states[1], symbol)
                     }
                 }
             }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -173,21 +173,21 @@ document.querySelector('#complete').addEventListener('click', () => {
         converter = new NFAConverter(nfa.visual.fsa)
     }
 
-    // try {
-    const changes = converter.complete()
-    if (changes.length > 0) {
-        for (const change of changes) {
-            const [newDFA, step] = change
-            dfa.visual.syncDFA(step, newDFA)
+    try {
+        const changes = converter.complete()
+        if (changes.length > 0) {
+            for (const change of changes) {
+                const [newDFA, step] = change
+                dfa.visual.syncDFA(step, newDFA)
+            }
         }
-    }
 
-    setEditButtonsState(false, true)
-    // } catch (e) {
-    //     showWarning('#nfa-warning', e.message)
-    //     converter = undefined
-    //     dfa.visual.reset()
-    // }
+        setEditButtonsState(false, true)
+    } catch (e) {
+        showWarning('#nfa-warning', e.message)
+        converter = undefined
+        dfa.visual.reset()
+    }
 })
 
 /**

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -173,21 +173,21 @@ document.querySelector('#complete').addEventListener('click', () => {
         converter = new NFAConverter(nfa.visual.fsa)
     }
 
-    try {
-        const changes = converter.complete()
-        if (changes.length > 0) {
-            for (const change of changes) {
-                const [newDFA, step] = change
-                dfa.visual.syncDFA(step, newDFA)
-            }
+    // try {
+    const changes = converter.complete()
+    if (changes.length > 0) {
+        for (const change of changes) {
+            const [newDFA, step] = change
+            dfa.visual.syncDFA(step, newDFA)
         }
-
-        setEditButtonsState(false, true)
-    } catch (e) {
-        showWarning('#nfa-warning', e.message)
-        converter = undefined
-        dfa.visual.reset()
     }
+
+    setEditButtonsState(false, true)
+    // } catch (e) {
+    //     showWarning('#nfa-warning', e.message)
+    //     converter = undefined
+    //     dfa.visual.reset()
+    // }
 })
 
 /**

--- a/src/js/test/nfa_converter.test.js
+++ b/src/js/test/nfa_converter.test.js
@@ -157,3 +157,94 @@ describe('NFA Conversion 2', () => {
         done()
     })
 })
+
+describe('NFA Conversion 3', () => {
+    const nfa = new FSA(['1', '2', '3'], ['a', 'b'], {
+        '1': {
+            'a': undefined,
+            'b': ['2'],
+            'ε': ['3']
+        },
+        '2': {
+            'a': ['1'],
+            'b': ['2'],
+            'ε': undefined
+        },
+        '3': {
+            'a': ['2', '3'],
+            'b': ['3'],
+            'ε': undefined
+        }
+    }, '1', ['2'])
+
+    const conversion = new NFAConverter(nfa)
+
+    it('should generate the initial DFA', done => {
+        const [dfa] = conversion.stepForward()
+
+        dfa.states.should.eql(['Ø', '1', '2', '1,2', '3', '1,3', '2,3', '1,2,3'])
+        dfa.alphabet.should.eql(['a', 'b'])
+        dfa.startState.should.eql('1,3')
+        dfa.acceptStates.should.eql(['2', '1,2', '2,3', '1,2,3'])
+        dfa.transitions.should.eql({
+            '1': { a: undefined, b: undefined },
+            '1,2': { a: undefined, b: undefined },
+            '1,2,3': { a: undefined, b: undefined },
+            '1,3': { a: undefined, b: undefined },
+            '2': { a: undefined, b: undefined },
+            '2,3': { a: undefined, b: undefined },
+            '3': { a: undefined, b: undefined },
+            'Ø': { a: undefined, b: undefined }
+        })
+
+        done()
+    })
+
+    it('should generate transitions', done => {
+        const dfa = conversion.step(16)
+
+        dfa.transitions.should.eql({
+            '1': { a: ['Ø'], b: ['2'] },
+            '1,2': { a: ['1,3'], b: ['2'] },
+            '1,2,3': { a: ['1,2,3'], b: ['2,3'] },
+            '1,3': { a: ['2,3'], b: ['2,3'] },
+            '2': { a: ['1,3'], b: ['2'] },
+            '2,3': { a: ['1,2,3'], b: ['2,3'] },
+            '3': { a: ['2,3'], b: ['3'] },
+            'Ø': { a: ['Ø'], b: ['Ø'] }
+        })
+
+        done()
+    })
+
+    it('should delete unreachable states', done => {
+        const dfa = conversion.step(5)
+
+        dfa.states.should.eql(['1,3', '2,3', '1,2,3'])
+        dfa.alphabet.should.eql(['a', 'b'])
+        dfa.startState.should.eql('1,3')
+        dfa.acceptStates.should.eql(['2,3', '1,2,3'])
+        dfa.transitions.should.eql({
+            '1,2,3': { a: ['1,2,3'], b: ['2,3'] },
+            '1,3': { a: ['2,3'], b: ['2,3'] },
+            '2,3': { a: ['1,2,3'], b: ['2,3'] }
+        })
+
+        done()
+    })
+
+    it('should delete redundant states', done => {
+        const dfa = conversion.step(1)
+
+        dfa.states.should.eql(['1,3', '2,3+1,2,3'])
+        dfa.alphabet.should.eql(['a', 'b'])
+        dfa.startState.should.eql('1,3')
+        dfa.acceptStates.should.eql(['2,3+1,2,3'])
+        dfa.transitions.should.eql({
+            '1,3': { a: ['2,3+1,2,3'], b: ['2,3+1,2,3'] },
+            '2,3+1,2,3': { a: ['2,3+1,2,3'], b: ['2,3+1,2,3'] }
+        })
+
+        done()
+    })
+})

--- a/src/js/test/nfa_converter.test.js
+++ b/src/js/test/nfa_converter.test.js
@@ -31,14 +31,14 @@ describe('NFA Conversion 1', () => {
         dfa.startState.should.eql('1,3')
         dfa.acceptStates.should.eql(['1', '1,2', '1,3', '1,2,3'])
         dfa.transitions.should.eql({
-            '1': { a: undefined, b: undefined },
-            '1,2': { a: undefined, b: undefined },
-            '1,2,3': { a: undefined, b: undefined },
-            '1,3': { a: undefined, b: undefined },
-            '2': { a: undefined, b: undefined },
-            '2,3': { a: undefined, b: undefined },
-            '3': { a: undefined, b: undefined },
-            'Ø': { a: undefined, b: undefined }
+            '1': {},
+            '1,2': {},
+            '1,2,3': {},
+            '1,3': {},
+            '2': {},
+            '2,3': {},
+            '3': {},
+            'Ø': {}
         })
 
         done()
@@ -110,14 +110,14 @@ describe('NFA Conversion 2', () => {
         dfa.startState.should.eql('q1')
         dfa.acceptStates.should.eql(['q1', 'q1,q2', 'q3', 'q1,q3', 'q2,q3', 'q1,q2,q3'])
         dfa.transitions.should.eql({
-            'q1': { 0: undefined, 1: undefined },
-            'q1,q2': { 0: undefined, 1: undefined },
-            'q1,q2,q3': { 0: undefined, 1: undefined },
-            'q1,q3': { 0: undefined, 1: undefined },
-            'q2': { 0: undefined, 1: undefined },
-            'q2,q3': { 0: undefined, 1: undefined },
-            'q3': { 0: undefined, 1: undefined },
-            'Ø': { 0: undefined, 1: undefined }
+            'q1': {},
+            'q1,q2': {},
+            'q1,q2,q3': {},
+            'q1,q3': {},
+            'q2': {},
+            'q2,q3': {},
+            'q3': {},
+            'Ø': {}
         })
 
         done()
@@ -187,14 +187,14 @@ describe('NFA Conversion 3', () => {
         dfa.startState.should.eql('1,3')
         dfa.acceptStates.should.eql(['2', '1,2', '2,3', '1,2,3'])
         dfa.transitions.should.eql({
-            '1': { a: undefined, b: undefined },
-            '1,2': { a: undefined, b: undefined },
-            '1,2,3': { a: undefined, b: undefined },
-            '1,3': { a: undefined, b: undefined },
-            '2': { a: undefined, b: undefined },
-            '2,3': { a: undefined, b: undefined },
-            '3': { a: undefined, b: undefined },
-            'Ø': { a: undefined, b: undefined }
+            '1': {},
+            '1,2': {},
+            '1,2,3': {},
+            '1,3': {},
+            '2': {},
+            '2,3': {},
+            '3': {},
+            'Ø': {}
         })
 
         done()


### PR DESCRIPTION
Following [homework problem 2](https://piazza.com/class_profile/get_resource/kirwgfim4dfsv/kl73les060f4a2), we can further reduce a DFA by combining redundant states with a loopback.

Previously, the fully reduced preset 3 DFA looked like:
![image](https://user-images.githubusercontent.com/8845512/120121033-4cdcc700-c16f-11eb-9057-6b62445b55ff.png)

Now, this PR reduces it even further to:
![image](https://user-images.githubusercontent.com/8845512/120121056-60882d80-c16f-11eb-9d9b-ef3642f506bc.png)
