### PR TITLE
add ability to undo steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,9 @@
                                                     <i class="mdi mdi-play" aria-hidden="true"></i></nobr>,
                                                 or all at <nobr>once
                                                     <i class="mdi mdi-skip-forward" aria-hidden="true"></i></nobr>. You
+                                                can revisit previous actions by going backwards <nobr><i
+                                                        class="mdi mdi-skip-previous" aria-hidden="true"></i></nobr>.
+                                                You
                                                 may drag nodes around to
                                                 reorganize
                                                 the visual layout. However, node-editing features are disabled. To
@@ -223,8 +226,14 @@
             <div class="box">
                 <div class="columns">
                     <div class="column">
-                        <button class="button blue-button conversion-button" id="step" style="width:100%;" disabled>
-                            <i class="mdi mdi-skip-next" aria-hidden="true"></i>Step
+                        <button class="button blue-button conversion-button" id="step-forward" style="width:100%;"
+                            disabled>
+                            <i class="mdi mdi-skip-next" aria-hidden="true"></i>Step Forward
+                        </button>
+                    </div>
+                    <div class="column">
+                        <button class="button blue-button" id="step-backward" style="width:100%;" disabled>
+                            <i class="mdi mdi-skip-previous" aria-hidden="true"></i>Step Backward
                         </button>
                     </div>
                     <div class="column">

--- a/src/js/fsa/animated_nfa_converter.js
+++ b/src/js/fsa/animated_nfa_converter.js
@@ -19,7 +19,7 @@ export default class AnimatedNFAConverter extends EventHandler {
         try {
             const [newDFA, step] = this.converter.stepForward()
             if (newDFA && step) {
-                this.visualDFA.syncDFA(step, newDFA)
+                this.visualDFA.performStep(step, newDFA)
                 document.querySelector('#dfa-conversion-step').innerHTML = step.desc
             } else {
                 this.stop()

--- a/src/js/fsa/nfa_converter.js
+++ b/src/js/fsa/nfa_converter.js
@@ -12,6 +12,9 @@ export default class NFAConverter {
         // dfa is the FSA that NFAConverter performs each step upon
         this.dfa = undefined
 
+        // steps is the list of steps that have occurred thus far
+        this.steps = []
+
         // state_index holds which state will have a transition generated next
         this.state_index = 0
 
@@ -24,6 +27,14 @@ export default class NFAConverter {
     }
 
     /**
+     * Clone the reference to the DFA
+     * This is useful for freezing the DFA's state in time for things such as undoing a step forward
+     */
+    cloneDFA () {
+        return new FSA(Object.assign([], this.dfa.states), Object.assign([], this.dfa.alphabet), Object.assign({}, this.dfa.transitions), this.dfa.startState, Object.assign([], Object.assign([], this.dfa.acceptStates)))
+    }
+
+    /**
      * Get all the unreachable states of the converted DFA
      *
      * @param {FSA} tempDFA A temporary DFA to work off of
@@ -32,7 +43,7 @@ export default class NFAConverter {
      */
     getUnreachableStates (tempDFA = undefined, list = []) {
         if (!tempDFA) {
-            tempDFA = new FSA(this.dfa.states, this.dfa.alphabet, this.dfa.transitions, this.dfa.startState, this.dfa.acceptStates)
+            tempDFA = this.cloneDFA()
         }
 
         const nodesWithIncomingEdges = []
@@ -105,11 +116,16 @@ export default class NFAConverter {
 
             this.dfa = new FSA(states, this.nfa.alphabet, transitions, startState, acceptStates)
 
-            return [this.dfa, {
+            const step = [this.cloneDFA(), {
                 type: 'initialize',
                 desc: 'Initialize the DFA'
             }]
+            this.steps.push(step)
+            return step
         }
+
+        const prevStateIndex = this.state_index
+        const prevAlphabetIndex = this.alphabet_index
 
         // If we've created all the transitions for the current state, move to the next state
         if (this.alphabet_index === this.dfa.alphabet.length) {
@@ -151,13 +167,17 @@ export default class NFAConverter {
             this.alphabet_index++
 
             const toState = this.dfa.transitions[state][symbol].join(',')
-            return [this.dfa, {
+            const step = [this.cloneDFA(), {
                 type: 'add_transition',
                 desc: `Add a transition from ${state} on input ${symbol} to ${toState}`,
                 fromState: state,
                 toState: toState,
-                symbol: symbol
+                symbol: symbol,
+                prevStateIndex: prevStateIndex,
+                prevAlphabetIndex: prevAlphabetIndex
             }]
+            this.steps.push(step)
+            return step
         }
 
         // At this point, we have generated all transitions
@@ -171,16 +191,54 @@ export default class NFAConverter {
             // Pop the first state from unreachableStates
             const stateToDelete = this.unreachableStates.shift()
 
-            this.dfa.removeState(stateToDelete)
-
-            return [this.dfa, {
+            const step = [this.cloneDFA(), {
                 type: 'delete_state',
                 desc: `Delete unreachable state ${stateToDelete}`,
-                state: stateToDelete
+                state: stateToDelete,
+                transitions: this.dfa.transitions[stateToDelete] !== undefined ? Object.assign({}, this.dfa.transitions[stateToDelete]) : undefined
             }]
+            this.steps.push(step)
+
+            this.dfa.removeState(stateToDelete)
+            return step
         }
 
         return [undefined, undefined]
+    }
+
+    /**
+     * Undo the previous step in the conversion process
+     *
+     * @returns {Array} The new DFA and the step that was performed
+     */
+    stepBackward () {
+        if (this.steps.length === 0) { return }
+
+        const [prevDFA, prevStep] = this.steps.pop()
+
+        // If we stepped all the way back, reinitialize everything
+        if (prevStep.type === 'initialize') {
+            this.dfa = undefined
+            this.steps = []
+            this.state_index = 0
+            this.alphabet_index = 0
+            this.unreachableStates = undefined
+
+            return [prevDFA, prevStep]
+        }
+
+        this.dfa = prevDFA
+
+        if (prevStep.prevStateIndex !== undefined && prevStep.prevAlphabetIndex !== undefined) {
+            this.state_index = prevStep.prevStateIndex
+            this.alphabet_index = prevStep.prevAlphabetIndex
+        }
+
+        if (prevStep.type === 'delete_state') {
+            this.unreachableStates.unshift(prevStep.state)
+        }
+
+        return [prevDFA, prevStep]
     }
 
     /**


### PR DESCRIPTION
This adds the ability for the user to step backward in the conversion process by undoing the previous step. For example, if the last step was to delete the unreachable node {1}, stepping backwards will recreate the node {1}.