### PR TITLE
fit state labels within the diameter of circle

### DIFF
--- a/src/js/canvas/drawables/circle.js
+++ b/src/js/canvas/drawables/circle.js
@@ -54,7 +54,11 @@ export default class Circle extends Drawable {
         rend.ctx.arc(this.loc.x, this.loc.y, this.options.radius, 0, 2 * Math.PI)
         rend.ctx.fill()
 
-        if (this.options.text) this.options.text.draw(rend)
+        if (this.options.text) {
+            // Fit the text within the circle's diameter
+            this.options.text.fitToWidth(2 * this.options.radius - 5, rend.ctx)
+            this.options.text.draw(rend)
+        }
 
         rend.resetColor()
     }

--- a/src/js/canvas/drawables/text.js
+++ b/src/js/canvas/drawables/text.js
@@ -23,6 +23,25 @@ export default class Text extends Drawable {
         return loc.distance(this.loc) < this.options.size
     }
 
+    /**
+     * Adjust the text's size until it fits within the given width
+     * @param {Number} width The max width the text can be
+     * @param {CanvasRenderingContext2D} ctx The canvas context
+     */
+    fitToWidth (width, ctx) {
+        while (true) {
+            ctx.font = `${this.options.size}px ${this.options.font}`
+            const renderedWidth = ctx.measureText(this.options.text).width
+
+            if (renderedWidth > width) {
+                this.options.size--
+                if (this.options.size < 4) break
+            } else {
+                break
+            }
+        }
+    }
+
     draw (rend) {
         rend.setColor(this.options.color)
 

--- a/src/js/fsa/visual_fsa.js
+++ b/src/js/fsa/visual_fsa.js
@@ -554,8 +554,7 @@ export default class VisualFSA extends EventHandler {
                     text: node.label,
                     size: NODE_LABEL_SIZE,
                     color: '#fff',
-                    font: 'Helvetica',
-                    outline: { color: color === NODE_COLOR ? NODE_COLOR : 'green', width: 6 }
+                    font: 'Helvetica'
                 }),
                 borderOptions: { color: '#000', width: 2 },
                 outlineOptions: outline


### PR DESCRIPTION
This changes the way a state label sits on the circle from this:

![image](https://user-images.githubusercontent.com/8845512/121917860-841cad80-cd03-11eb-9ceb-517f659d8c39.png)

to this:

![image](https://user-images.githubusercontent.com/8845512/121917910-90086f80-cd03-11eb-8dfa-c86b51bdae1f.png)
